### PR TITLE
Handle when result is Error & not PolygolfError

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -188,7 +188,7 @@ function renderResult(compilationResult) {
   if (typeof result !== 'string') {
     let output = result.toString();
 
-    if (compilationResult.language === undefined) { // Fatal error
+    if (compilationResult.location === undefined) { // Fatal error
       const stack = result.stack;
       if (stack != null) {
         output += '\n\n' + stack;

--- a/src/index.js
+++ b/src/index.js
@@ -152,14 +152,9 @@ function renderTabs(results) {
     button.className = 'nav-link';
     if (first)
       button.classList.add('active');
-    if (typeof compilationResult.result !== 'string' && compilationResult.location === undefined) {
-      button.textContent = 'Fatal error';
-    } else {
-      button.textContent = compilationResult.language;
-      if (compilationResult.length !== undefined) {
-        button.innerHTML += ` <sup>${compilationResult.length}</sup>`;
-      }
-    }
+    button.textContent = compilationResult.language;
+    if (compilationResult.length !== undefined) {
+      button.innerHTML += ` <sup>${compilationResult.length}</sup>`;
     button.type = 'button';
     button.setAttribute('data-bs-toggle', 'tab');
 
@@ -192,14 +187,14 @@ function renderResult(compilationResult) {
   if (typeof result !== 'string') {
     let output = result.toString();
 
-    if (compilationResult.location === undefined) { // Fatal error
+    if (compilationResult.language === "Fatal error") { // Fatal error
       const stack = result.stack;
       if (stack != null) {
         output += '\n\n' + stack;
       }
-    } else { // PolygolfError
+    } else { // language error
       const location = compilationResult.location;
-      if (location !== null) {
+      if (location != null) {
         const startLine = location.line === 0 ? 0 : location.line - 2;
         output += '\n\n' +
           lastCompilationResults.source

--- a/src/index.js
+++ b/src/index.js
@@ -97,19 +97,19 @@ function setTheme(theme) {
 setTheme(getTheme());
 
 
-function getSource(){
+function getSource() {
   return editor.state.doc.toString();
 }
 
-function getObjective(){
+function getObjective() {
   return document.getElementById('objectiveSelect').value;
 }
 
-function getIsAllVariants(){
+function getIsAllVariants() {
   return document.getElementById('getAllVariantsCheckBox').checked;
 }
 
-function getLanguageName(){
+function getLanguageName() {
   return document.getElementById('languageSelect').value;
 }
 
@@ -152,9 +152,13 @@ function renderTabs(results) {
     button.className = 'nav-link';
     if (first)
       button.classList.add('active');
-    button.textContent = compilationResult.language ?? 'Fatal error';
-    if (compilationResult.length !== undefined) {
-      button.innerHTML += ` <sup>${compilationResult.length}</sup>`;
+    if (typeof compilationResult.result !== 'string' && compilationResult.location === undefined) {
+      button.textContent = 'Fatal error';
+    } else {
+      button.textContent = compilationResult.language;
+      if (compilationResult.length !== undefined) {
+        button.innerHTML += ` <sup>${compilationResult.length}</sup>`;
+      }
     }
     button.type = 'button';
     button.setAttribute('data-bs-toggle', 'tab');

--- a/src/worker.js
+++ b/src/worker.js
@@ -26,7 +26,7 @@ onmessage = (event) => {
       }
     }
   } catch (e) {
-    compilationResults = [{ result: e }];
+    compilationResults = [{ language: "Fatal error", result: e }];
   }
 
   data.results = compilationResults;


### PR DESCRIPTION
Polygolf can return an Error that is not a PolygolfError (this is not done on purpose, but means a programmer error). In such case the playground currently dereferences an undefined. This makes it so that it prints the error instead.